### PR TITLE
Remove outdated reference to CVE schema

### DIFF
--- a/src/views/ProgramOrganization/WorkingGroups.vue
+++ b/src/views/ProgramOrganization/WorkingGroups.vue
@@ -87,10 +87,6 @@
                       <a href="https://github.com/CVEProject/cvelistV5" target="_blank">CVE List Bulk Downloads Repository</a>
                     </li>
                     <li class="cve-task-tile-list-item">
-                      <a href="https://github.com/CVEProject/automation-working-group/tree/master/cve_json_schema" target="_blank">
-                        CVE JSON Schema Project</a>
-                    </li>
-                    <li class="cve-task-tile-list-item">
                       <a href="https://github.com/CVEProject/automation-working-group" target="_blank">AWG GitHub Repository</a>
                     </li>
                   </ul>


### PR DESCRIPTION
The CVE v5 schema lives in its own repo, linked from the CVE QWG list of repositories.